### PR TITLE
Request licensing from upstream

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,5 @@
+Copyright 2013-2015 jonuwz (https://github.com/jonuwz)
+
+TODO: Select approriate license here.
+
+Example: https://creativecommons.org/choose/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# puppet-ipa
+
+Custom types and providers for Identity Policy Audit (IPA).
+
+See License.md for Licensing.
+
+For more information on IPA see http://www.freeipa.org.
+
+For IPA licensing see http://www.freeipa.org/page/License.
+
 ----------------
 
 ### ipa_group

--- a/ipa/lib/puppet/provider/ipa_group/ipa.rb
+++ b/ipa/lib/puppet/provider/ipa_group/ipa.rb
@@ -1,3 +1,12 @@
+################################################################################
+#
+# puppet/provider/ipa_group/ipa.rb
+#
+# Copyright 2013-2015 jonuwz (https://github.com/jonuwz)
+#
+# See LICENSE.md for Licensing.
+#
+################################################################################
 require 'puppet/util/ipajson'
 require 'puppet/provider/ipabase'
 

--- a/ipa/lib/puppet/provider/ipa_hbacrule/ipa.rb
+++ b/ipa/lib/puppet/provider/ipa_hbacrule/ipa.rb
@@ -1,3 +1,12 @@
+################################################################################
+#
+# puppet/provider/ipa_hbacrule/ipa.rb
+#
+# Copyright 2013-2015 jonuwz (https://github.com/jonuwz)
+#
+# See LICENSE.md for Licensing.
+#
+################################################################################
 require 'puppet/util/ipajson'
 require 'puppet/provider/ipabase'
 

--- a/ipa/lib/puppet/provider/ipa_hbacsvc/ipa.rb
+++ b/ipa/lib/puppet/provider/ipa_hbacsvc/ipa.rb
@@ -1,3 +1,12 @@
+################################################################################
+#
+# puppet/provider/ipa_hbacsvc/ipa.rb
+#
+# Copyright 2013-2015 jonuwz (https://github.com/jonuwz)
+#
+# See LICENSE.md for Licensing.
+#
+################################################################################
 require 'puppet/util/ipajson'
 require 'puppet/provider/ipabase'
 

--- a/ipa/lib/puppet/provider/ipa_hbacsvcgroup/ipa.rb
+++ b/ipa/lib/puppet/provider/ipa_hbacsvcgroup/ipa.rb
@@ -1,3 +1,12 @@
+################################################################################
+#
+# puppet/provider/ipa_hbacsvcgroup/ipa.rb
+#
+# Copyright 2013-2015 jonuwz (https://github.com/jonuwz)
+#
+# See LICENSE.md for Licensing.
+#
+################################################################################
 require 'puppet/util/ipajson'
 require 'puppet/provider/ipabase'
 

--- a/ipa/lib/puppet/provider/ipa_host/ipa.rb
+++ b/ipa/lib/puppet/provider/ipa_host/ipa.rb
@@ -1,3 +1,12 @@
+################################################################################
+#
+# puppet/provider/ipa_host/ipa.rb
+#
+# Copyright 2013-2015 jonuwz (https://github.com/jonuwz)
+#
+# See LICENSE.md for Licensing.
+#
+################################################################################
 require 'puppet/util/ipajson'
 require 'puppet/provider/ipabase'
 

--- a/ipa/lib/puppet/provider/ipa_hostgroup/ipa.rb
+++ b/ipa/lib/puppet/provider/ipa_hostgroup/ipa.rb
@@ -1,3 +1,12 @@
+################################################################################
+#
+# puppet/provider/ipa_hostgroup/ipa.rb
+#
+# Copyright 2013-2015 jonuwz (https://github.com/jonuwz)
+#
+# See LICENSE.md for Licensing.
+#
+################################################################################
 require 'puppet/util/ipajson'
 require 'puppet/provider/ipabase'
 

--- a/ipa/lib/puppet/provider/ipa_sudocmd/ipa.rb
+++ b/ipa/lib/puppet/provider/ipa_sudocmd/ipa.rb
@@ -1,3 +1,12 @@
+################################################################################
+#
+# puppet/provider/ipa_sudocmd/ipa.rb
+#
+# Copyright 2013-2015 jonuwz (https://github.com/jonuwz)
+#
+# See LICENSE.md for Licensing.
+#
+################################################################################
 require 'puppet/util/ipajson'
 require 'puppet/provider/ipabase'
 

--- a/ipa/lib/puppet/provider/ipa_sudocmdgroup/ipa.rb
+++ b/ipa/lib/puppet/provider/ipa_sudocmdgroup/ipa.rb
@@ -1,3 +1,12 @@
+################################################################################
+#
+# puppet/provider/ipa_sudocmdgroup/ipa.rb
+#
+# Copyright 2013-2015 jonuwz (https://github.com/jonuwz)
+#
+# See LICENSE.md for Licensing.
+#
+################################################################################
 require 'puppet/util/ipajson'
 require 'puppet/provider/ipabase'
 

--- a/ipa/lib/puppet/provider/ipa_sudorule/ipa.rb
+++ b/ipa/lib/puppet/provider/ipa_sudorule/ipa.rb
@@ -1,3 +1,12 @@
+################################################################################
+#
+# puppet/provider/ipa_sudorule/ipa.rb
+#
+# Copyright 2013-2015 jonuwz (https://github.com/jonuwz)
+#
+# See LICENSE.md for Licensing.
+#
+################################################################################
 require 'puppet/util/ipajson'
 require 'puppet/provider/ipabase'
 

--- a/ipa/lib/puppet/provider/ipa_user/ipa.rb
+++ b/ipa/lib/puppet/provider/ipa_user/ipa.rb
@@ -1,3 +1,12 @@
+################################################################################
+#
+# puppet/provider/ipa_user/ipa.rb
+#
+# Copyright 2013-2015 jonuwz (https://github.com/jonuwz)
+#
+# See LICENSE.md for Licensing.
+#
+################################################################################
 require 'puppet/util/ipajson'
 require 'puppet/provider/ipabase'
 

--- a/ipa/lib/puppet/provider/ipabase.rb
+++ b/ipa/lib/puppet/provider/ipabase.rb
@@ -1,3 +1,12 @@
+################################################################################
+#
+# puppet/provider/ipabase.rb
+#
+# Copyright 2013-2015 jonuwz (https://github.com/jonuwz)
+#
+# See LICENSE.md for Licensing.
+#
+################################################################################
 require 'puppet/provider'
 require 'puppet/util/ipajson'
 

--- a/ipa/lib/puppet/type/ipa_group.rb
+++ b/ipa/lib/puppet/type/ipa_group.rb
@@ -1,3 +1,12 @@
+################################################################################
+#
+# puppet/type/ipa_group.rb
+#
+# Copyright 2013-2015 jonuwz (https://github.com/jonuwz)
+#
+# See LICENSE.md for Licensing.
+#
+################################################################################
 Puppet::Type.newtype(:ipa_group) do
   @doc = <<-'EOS'
     Manages user groups within IPA.

--- a/ipa/lib/puppet/type/ipa_hbacrule.rb
+++ b/ipa/lib/puppet/type/ipa_hbacrule.rb
@@ -1,3 +1,12 @@
+################################################################################
+#
+# puppet/type/ipa_hbacrule.rb
+#
+# Copyright 2013-2015 jonuwz (https://github.com/jonuwz)
+#
+# See LICENSE.md for Licensing.
+#
+################################################################################
 Puppet::Type.newtype(:ipa_hbacrule) do
   @doc = <<-'EOS'
     Manages Host Based Access Control rules within IPA.

--- a/ipa/lib/puppet/type/ipa_hbacsvc.rb
+++ b/ipa/lib/puppet/type/ipa_hbacsvc.rb
@@ -1,3 +1,12 @@
+################################################################################
+#
+# puppet/type/ipa_hbacsvc.rb
+#
+# Copyright 2013-2015 jonuwz (https://github.com/jonuwz)
+#
+# See LICENSE.md for Licensing.
+#
+################################################################################
 Puppet::Type.newtype(:ipa_hbacsvc) do
 
   @doc = <<-'EOS'

--- a/ipa/lib/puppet/type/ipa_hbacsvcgroup.rb
+++ b/ipa/lib/puppet/type/ipa_hbacsvcgroup.rb
@@ -1,3 +1,12 @@
+################################################################################
+#
+# puppet/type/ipa_hbacsvcgroup.rb
+#
+# Copyright 2013-2015 jonuwz (https://github.com/jonuwz)
+#
+# See LICENSE.md for Licensing.
+#
+################################################################################
 Puppet::Type.newtype(:ipa_hbacsvcgroup) do
   @doc = <<-'EOS'
     Manages Host Based Access Control service groups within IPA.

--- a/ipa/lib/puppet/type/ipa_host.rb
+++ b/ipa/lib/puppet/type/ipa_host.rb
@@ -1,3 +1,12 @@
+################################################################################
+#
+# puppet/type/ipa_host.rb
+#
+# Copyright 2013-2015 jonuwz (https://github.com/jonuwz)
+#
+# See LICENSE.md for Licensing.
+#
+################################################################################
 Puppet::Type.newtype(:ipa_host) do
   @doc = <<-'EOS'
     Manages host details within IPA.

--- a/ipa/lib/puppet/type/ipa_hostgroup.rb
+++ b/ipa/lib/puppet/type/ipa_hostgroup.rb
@@ -1,3 +1,12 @@
+################################################################################
+#
+# puppet/type/ipa_hostgroup.rb
+#
+# Copyright 2013-2015 jonuwz (https://github.com/jonuwz)
+#
+# See LICENSE.md for Licensing.
+#
+################################################################################
 Puppet::Type.newtype(:ipa_hostgroup) do
   @doc = <<-'EOS'
     Manages hostgroups within IPA.

--- a/ipa/lib/puppet/type/ipa_sudocmd.rb
+++ b/ipa/lib/puppet/type/ipa_sudocmd.rb
@@ -1,3 +1,12 @@
+################################################################################
+#
+# puppet/type/ipa_sudocmd.rb
+#
+# Copyright 2013-2015 jonuwz (https://github.com/jonuwz)
+#
+# See LICENSE.md for Licensing.
+#
+################################################################################
 Puppet::Type.newtype(:ipa_sudocmd) do
   @doc = <<-'EOS'
     Manages Sudo commands within IPA.

--- a/ipa/lib/puppet/type/ipa_sudocmdgroup.rb
+++ b/ipa/lib/puppet/type/ipa_sudocmdgroup.rb
@@ -1,3 +1,12 @@
+################################################################################
+#
+# puppet/type/ipa_sudocmdgroup.rb
+#
+# Copyright 2013-2015 jonuwz (https://github.com/jonuwz)
+#
+# See LICENSE.md for Licensing.
+#
+################################################################################
 Puppet::Type.newtype(:ipa_sudocmdgroup) do
   @doc = <<-'EOS'
     Manages Sudo command groups within IPA.

--- a/ipa/lib/puppet/type/ipa_sudorule.rb
+++ b/ipa/lib/puppet/type/ipa_sudorule.rb
@@ -1,3 +1,12 @@
+################################################################################
+#
+# puppet/type/ipa_sudorule.rb
+#
+# Copyright 2013-2015 jonuwz (https://github.com/jonuwz)
+#
+# See LICENSE.md for Licensing.
+#
+################################################################################
 Puppet::Type.newtype(:ipa_sudorule) do
 
   @doc = <<-'EOS'

--- a/ipa/lib/puppet/type/ipa_user.rb
+++ b/ipa/lib/puppet/type/ipa_user.rb
@@ -1,3 +1,12 @@
+################################################################################
+#
+# puppet/type/ipa_user.rb
+#
+# Copyright 2013-2015 jonuwz (https://github.com/jonuwz)
+#
+# See LICENSE.md for Licensing.
+#
+################################################################################
 Puppet::Type.newtype(:ipa_user) do
 
   @doc = <<-EOS

--- a/ipa/lib/puppet/util/ipajson.rb
+++ b/ipa/lib/puppet/util/ipajson.rb
@@ -1,3 +1,12 @@
+################################################################################
+#
+# puppet/util/ipajson.rb
+#
+# Copyright 2013-2015 jonuwz (https://github.com/jonuwz)
+#
+# See LICENSE.md for Licensing.
+#
+################################################################################
 module IPAcommon
 
   @@IPAfind_element = {


### PR DESCRIPTION
I would like to base a complete module off of the API work here.  To do so I need clarification on the license on the code.  

Typically Puppet code is published Apache 2.0 or GPL. This extensive set of libraries for interacting with IPA does not appear to have any license, leaving the copyrights at the default 'All Rights Reserved.'

This push request adds explicit copyright headers and an empty license file with a TODO on selecting a license.  This is a pure documentation update.  No organization changes to the code or changes to the function of the code is given.

Please select and push an explicit license.  This is so that I might pull that documentation and start doing work that others can use without exposing anybody to risk.  If the license chosen does not permit me to modify the code (e.g. build a forge-compatible module layout or write unit tests) I shall desist and remove my fork.

Thank you for publishing this very nice library of native types and providers.
